### PR TITLE
empty string returns correctly

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -35,7 +35,7 @@ def set_coins(db, session):
                 error="Unspecified error.",
                 admin=admin.admin,
                 )
-    if not dpt:#Decrypt returns False if there was a padding exceptionu
+    if dpt is False:#Decrypt returns False if there was a padding exceptionu
         return template(
                 "profile",
                 user=admin,


### PR DESCRIPTION
A full block of padding correctly decrypts to `b''` . This empty byte string is set to `dpt` in `admin.py`. A padding error is returned when `not dpt` is true. Unfortunately, `not b''` returns true so the server accidentally sends a  padding error when the full padding block is decrypted correctly. By checking if `dpt is False` a padding error is only returned when the decryption returns `False`.